### PR TITLE
Do not change the display of the env badge on hover

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -19,6 +19,7 @@
 /* Admin bar background colors */
 
 #wpadminbar ul li#wp-admin-bar-det_env_type {
+	pointer-events: none;
 	background-color: #0087b1;
 }
 


### PR DESCRIPTION
It is weird that it looks "clickable" and change colors when you hover. One line of CSS fixes that.