### PR TITLE
Only enqueue CSS if the admin bar is showing

### DIFF
--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -101,6 +101,11 @@ class Plugin {
 		if ( ! function_exists( 'wp_get_environment_type' ) ) {
 			return false;
 		}
+		
+		// If the admin bar is not showing there is no place to display the environment type.
+		if ( ! is_admin_bar_showing() ) {
+			return false;
+		}
 
 		if ( is_admin() ) {
 			// Display in wp-admin for any role above subscriber.


### PR DESCRIPTION
When a logged in user with 'Show Toolbar when viewing site' turned off in their profile visits the front-end, the CSS styles were still being enqueued even though there is no admin bar. This checks to see if the admin bar is showing and if not set returns `should_display` as `false`. (May make the `is_user_logged_in()` check redundant as that is part of `is_admin_bar_showing()`.)