### PR TITLE
Accessibility improvements

### DIFF
--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -81,7 +81,6 @@ class Plugin {
 				'parent'=> 'top-secondary',
 				'title' => '<span class="ab-icon" aria-hidden="true"></span><span class="ab-label">' . esc_html( ucfirst( $env_type ) ) . '</span>',
 				'meta'  => array(
-					'title' => __( 'Environment Type', 'display-environment-type' ),
 					'class' => 'det-' . sanitize_title( $env_type ),
 				),
 			));

--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -79,7 +79,7 @@ class Plugin {
 			$admin_bar->add_menu( array(
 				'id'    => 'det_env_type',
 				'parent'=> 'top-secondary',
-				'title' => '<span class="ab-icon"></span><span class="ab-label">' . esc_html( ucfirst( $env_type ) ) . '</span>',
+				'title' => '<span class="ab-icon" aria-hidden="true"></span><span class="ab-label">' . esc_html( ucfirst( $env_type ) ) . '</span>',
 				'meta'  => array(
 					'title' => __( 'Environment Type', 'display-environment-type' ),
 					'class' => 'det-' . sanitize_title( $env_type ),

--- a/css/admin.css
+++ b/css/admin.css
@@ -17,10 +17,13 @@
 }
 
 /* Admin bar background colors */
+#wpadminbar ul li#wp-admin-bar-det_env_type .ab-label {
+	color: #fff;
+}
 
 #wpadminbar ul li#wp-admin-bar-det_env_type {
 	pointer-events: none;
-	background-color: #0087b1;
+	background-color: #0080a8;
 }
 
 #wpadminbar ul li#wp-admin-bar-det_env_type.det-production {
@@ -30,9 +33,13 @@
 #wpadminbar ul li#wp-admin-bar-det_env_type.det-staging {
 	background-color: #d79d00;
 }
+#wpadminbar ul li#wp-admin-bar-det_env_type.det-staging .ab-label,
+#wpadminbar ul li#wp-admin-bar-det_env_type.det-staging .ab-icon::before {
+	color: #000;
+}
 
 #wpadminbar ul li#wp-admin-bar-det_env_type.det-development {
-	background-color: #3b9843;
+	background-color: #34863b;
 }
 
 /* Admin bar icons */

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,18 +1,18 @@
 /* At a glance icons */
 
-#dashboard_right_now li > span.det-env-type:before {
+#dashboard_right_now li > span.det-env-type::before {
 	content: "\f339";
 }
 
-#dashboard_right_now li > span.det-env-type.det-production:before {
+#dashboard_right_now li > span.det-env-type.det-production::before {
 	content: "\f319";
 }
 
-#dashboard_right_now li > span.det-env-type.det-staging:before {
+#dashboard_right_now li > span.det-env-type.det-staging::before {
 	content: "\f111";
 }
 
-#dashboard_right_now li > span.det-env-type.det-development:before {
+#dashboard_right_now li > span.det-env-type.det-development::before {
 	content: "\f107";
 }
 
@@ -44,23 +44,23 @@
 
 /* Admin bar icons */
 
-#wp-admin-bar-det_env_type > div > span.ab-icon:before {
+#wp-admin-bar-det_env_type > div > span.ab-icon::before {
 	content: "\f339";
 	top: 2px;
 	color: inherit;
 }
 
-#wp-admin-bar-det_env_type.det-production > div > span.ab-icon:before {
+#wp-admin-bar-det_env_type.det-production > div > span.ab-icon::before {
 	content: "\f319";
 	top: 3px;
 }
 
-#wp-admin-bar-det_env_type.det-staging > div > span.ab-icon:before {
+#wp-admin-bar-det_env_type.det-staging > div > span.ab-icon::before {
 	content: "\f111";
 	top: 1px;
 }
 
-#wp-admin-bar-det_env_type.det-development > div > span.ab-icon:before {
+#wp-admin-bar-det_env_type.det-development > div > span.ab-icon::before {
 	content: "\f107";
 	top: 2px;
 }

--- a/css/admin.css
+++ b/css/admin.css
@@ -17,13 +17,16 @@
 }
 
 /* Admin bar background colors */
-#wpadminbar ul li#wp-admin-bar-det_env_type .ab-label {
-	color: #fff;
+
+#wpadminbar ul li#wp-admin-bar-det_env_type .ab-label,
+#wpadminbar ul li#wp-admin-bar-det_env_type .ab-item {
+	color: inherit;
 }
 
 #wpadminbar ul li#wp-admin-bar-det_env_type {
 	pointer-events: none;
 	background-color: #0080a8;
+	color: #fff;
 }
 
 #wpadminbar ul li#wp-admin-bar-det_env_type.det-production {
@@ -32,9 +35,6 @@
 
 #wpadminbar ul li#wp-admin-bar-det_env_type.det-staging {
 	background-color: #d79d00;
-}
-#wpadminbar ul li#wp-admin-bar-det_env_type.det-staging .ab-label,
-#wpadminbar ul li#wp-admin-bar-det_env_type.det-staging .ab-icon::before {
 	color: #000;
 }
 
@@ -47,6 +47,7 @@
 #wp-admin-bar-det_env_type > div > span.ab-icon:before {
 	content: "\f339";
 	top: 2px;
+	color: inherit;
 }
 
 #wp-admin-bar-det_env_type.det-production > div > span.ab-icon:before {


### PR DESCRIPTION
This closes #9.

It makes three accessibility-related changes and a bit of CSS cleanup.

The three changes:

1. Add `aria-hidden="true"` to icons to ensure screen readers don't announce the icon characters
2. Adjust colors so they all have 4.5:1 contrast, meeting WCAG 2.2, Level AA standards
3. Remove the `title` attribute which A) rarely is announced by screen readers and B) was no longer working due to the addition of `pointer-events: none` in a previous release

The cleanup: 

1. As part of this change, I made it so the `color` property is inherited by the `.ab-label` and `.ab-icon` elements so that the accessible `background-color`/`color` combinations can be set together on the item parent.
2. And finally, I adjusted the `:before` pseudo-element selectors to use the correct `::` syntax.

## Screenshots
![Local environment with blue background, white text, and lightbulb icon](https://github.com/roytanck/display-environment-type/assets/1238696/55ce3b2d-bf7a-45c5-9ac7-c34fa487e502)

![Staging environment with yellow background, black text, and gear icon](https://github.com/roytanck/display-environment-type/assets/1238696/bcf17509-be34-4ea5-87ed-b8001148f3b1)

![Development environment with green background, white text, and wrench icon](https://github.com/roytanck/display-environment-type/assets/1238696/d6aadf05-ed70-4656-b6c2-6a23d05e25bb)

![Production environment with red background, white text, and western hemisphere globe icon](https://github.com/roytanck/display-environment-type/assets/1238696/392d59b8-20bd-4f6d-82dd-08190e42e918)